### PR TITLE
Modernize rust-punkt to the 2021 spec of Rust language

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,18 +1,28 @@
 [package]
 name            = "punkt"
-version         = "1.0.5"
+version         = "1.0.6"
 authors         = ["Ferris Tseng <ferristseng@fastmail.fm>"]
 keywords        = ["punkt", "sentence", "token", "tokenizer"]
 license         = "MIT/Apache-2.0"
 repository      = "https://github.com/ferristseng/rust-punkt"
 description     = "An implementation of a Punkt sentence tokenizer"
 readme          = "README.md"
+edition         = "2021"
 
 [dependencies]
-num             = "0.1"
-phf             = { version = "0.7", features = ["macros"] }
-rustc-serialize = "0.3"
-rust-freqdist   = "0.1"
+num             = "0.4"
+phf             = { version = "0.11", features = ["macros"] }
+serde           = { version = "1.0", features = ["derive"] }
+serde_json      = "1.0"
 
 [dev-dependencies]
-walkdir         = "0.1"
+walkdir         = "2.3"
+criterion       = "0.5"
+
+[[bench]]
+name = "tokenizers"
+harness = false
+
+[[bench]]
+name = "trainers"
+harness = false

--- a/benches/tokenizers.rs
+++ b/benches/tokenizers.rs
@@ -1,0 +1,93 @@
+// Copyright 2016 rust-punkt developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use punkt::params::Standard;
+use punkt::WordTokenizer;
+use punkt::{SentenceTokenizer, TrainingData};
+
+fn word_tokenizer_bench(c: &mut Criterion) {
+  let mut group = c.benchmark_group("WordTokenizer");
+
+  // Short document
+  let short_doc = include_str!("../test/raw/sigma-wiki.txt");
+  group.bench_function("short_doc", |b| {
+    b.iter(|| {
+      let t: WordTokenizer<Standard> = WordTokenizer::new(black_box(short_doc));
+      let _: Vec<_> = t.collect();
+    })
+  });
+
+  // Medium document
+  let medium_doc = include_str!("../test/raw/npr-article-01.txt");
+  group.bench_function("medium_doc", |b| {
+    b.iter(|| {
+      let t: WordTokenizer<Standard> = WordTokenizer::new(black_box(medium_doc));
+      let _: Vec<_> = t.collect();
+    })
+  });
+
+  // Long document
+  let long_doc = include_str!("../test/raw/the-sayings-of-confucius.txt");
+  group.bench_function("long_doc", |b| {
+    b.iter(|| {
+      let t: WordTokenizer<Standard> = WordTokenizer::new(black_box(long_doc));
+      let _: Vec<_> = t.collect();
+    })
+  });
+
+  // Very long document
+  let very_long_doc = include_str!("../test/raw/pride-and-prejudice.txt");
+  group.bench_function("very_long_doc", |b| {
+    b.iter(|| {
+      let t: WordTokenizer<Standard> = WordTokenizer::new(black_box(very_long_doc));
+      let _: Vec<_> = t.collect();
+    })
+  });
+
+  group.finish();
+}
+
+fn sentence_tokenizer_bench(c: &mut Criterion) {
+  let mut group = c.benchmark_group("SentenceTokenizer");
+
+  // Short document
+  let short_doc = include_str!("../test/raw/sigma-wiki.txt");
+  let short_data = TrainingData::english();
+  group.bench_function("short_doc", |b| {
+    b.iter(|| {
+      let t = SentenceTokenizer::<Standard>::new(black_box(short_doc), &short_data);
+      let _: Vec<_> = t.collect();
+    })
+  });
+
+  // Medium document
+  let medium_doc = include_str!("../test/raw/npr-article-01.txt");
+  let medium_data = TrainingData::english();
+  group.bench_function("medium_doc", |b| {
+    b.iter(|| {
+      let t = SentenceTokenizer::<Standard>::new(black_box(medium_doc), &medium_data);
+      let _: Vec<_> = t.collect();
+    })
+  });
+
+  // Long document
+  let long_doc = include_str!("../test/raw/pride-and-prejudice.txt");
+  let long_data = TrainingData::english();
+  group.bench_function("long_doc", |b| {
+    b.iter(|| {
+      let t = SentenceTokenizer::<Standard>::new(black_box(long_doc), &long_data);
+      let _: Vec<_> = t.collect();
+    })
+  });
+
+  group.finish();
+}
+
+criterion_group!(benches, word_tokenizer_bench, sentence_tokenizer_bench);
+criterion_main!(benches);

--- a/benches/trainers.rs
+++ b/benches/trainers.rs
@@ -1,0 +1,60 @@
+// Copyright 2016 rust-punkt developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use punkt::params::Standard;
+use punkt::{Trainer, TrainingData};
+
+fn trainer_bench(c: &mut Criterion) {
+  let mut group = c.benchmark_group("Trainer");
+
+  // Short document
+  let short_doc = include_str!("../test/raw/sigma-wiki.txt");
+  group.bench_function("short_doc", |b| {
+    b.iter(|| {
+      let mut data = TrainingData::new();
+      let trainer: Trainer<Standard> = Trainer::new();
+      trainer.train(black_box(short_doc), &mut data);
+    })
+  });
+
+  // Medium document
+  let medium_doc = include_str!("../test/raw/npr-article-01.txt");
+  group.bench_function("medium_doc", |b| {
+    b.iter(|| {
+      let mut data = TrainingData::new();
+      let trainer: Trainer<Standard> = Trainer::new();
+      trainer.train(black_box(medium_doc), &mut data);
+    })
+  });
+
+  // Long document
+  let long_doc = include_str!("../test/raw/the-sayings-of-confucius.txt");
+  group.bench_function("long_doc", |b| {
+    b.iter(|| {
+      let mut data = TrainingData::new();
+      let trainer: Trainer<Standard> = Trainer::new();
+      trainer.train(black_box(long_doc), &mut data);
+    })
+  });
+
+  // Very long document
+  let very_long_doc = include_str!("../test/raw/pride-and-prejudice.txt");
+  group.bench_function("very_long_doc", |b| {
+    b.iter(|| {
+      let mut data = TrainingData::new();
+      let trainer: Trainer<Standard> = Trainer::new();
+      trainer.train(black_box(very_long_doc), &mut data);
+    })
+  });
+
+  group.finish();
+}
+
+criterion_group!(benches, trainer_bench);
+criterion_main!(benches);

--- a/examples/custom-parameters.rs
+++ b/examples/custom-parameters.rs
@@ -1,11 +1,6 @@
-#![feature(proc_macro_hygiene)]
-
-extern crate phf;
-extern crate punkt;
-
+use phf::phf_set;
 use punkt::params::*;
 use punkt::{SentenceTokenizer, Trainer, TrainingData};
-use phf::phf_set;
 
 struct MyParams;
 

--- a/examples/typical-usage.rs
+++ b/examples/typical-usage.rs
@@ -1,7 +1,5 @@
-extern crate punkt;
-
-use punkt::{SentenceTokenizer, Trainer, TrainingData};
 use punkt::params::Standard;
+use punkt::{SentenceTokenizer, Trainer, TrainingData};
 
 fn main() {
   let docs = [

--- a/src/freq_dist.rs
+++ b/src/freq_dist.rs
@@ -1,0 +1,88 @@
+// Copyright 2016 rust-punkt developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use std::collections::HashMap;
+use std::hash::Hash;
+use std::ops::Index;
+
+/// A frequency distribution that keeps track of the number of times
+/// each item is seen.
+#[derive(Debug, Clone)]
+pub struct FrequencyDistribution<T>
+where
+  T: Eq + Hash,
+{
+  counts: HashMap<T, usize>,
+  total_count: usize,
+}
+
+impl<T> FrequencyDistribution<T>
+where
+  T: Eq + Hash,
+{
+  /// Creates a new empty frequency distribution.
+  pub fn new() -> Self {
+    FrequencyDistribution {
+      counts: HashMap::new(),
+      total_count: 0,
+    }
+  }
+
+  /// Adds an item to the frequency distribution, incrementing its count.
+  /// Returns the new count of the item.
+  pub fn insert<U>(&mut self, item: U) -> usize
+  where
+    U: Into<T>,
+  {
+    let item = item.into();
+    let count = self.counts.entry(item).or_insert(0);
+    *count += 1;
+    self.total_count += 1;
+    *count
+  }
+
+  /// Gets the frequency of an item.
+  pub fn get<Q>(&self, item: &Q) -> usize
+  where
+    T: std::borrow::Borrow<Q>,
+    Q: Hash + Eq + ?Sized,
+  {
+    self.counts.get(item).copied().unwrap_or(0)
+  }
+
+  /// Gets the total number of items counted (sum of all frequencies).
+  pub fn sum_counts(&self) -> usize {
+    self.total_count
+  }
+
+  /// Returns an iterator over the keys (items) in the distribution.
+  pub fn keys(&self) -> impl Iterator<Item = &T> {
+    self.counts.keys()
+  }
+}
+
+impl<T> Default for FrequencyDistribution<T>
+where
+  T: Eq + Hash,
+{
+  fn default() -> Self {
+    Self::new()
+  }
+}
+
+impl<T, Q> Index<&Q> for FrequencyDistribution<T>
+where
+  T: Eq + Hash + std::borrow::Borrow<Q>,
+  Q: Hash + Eq + ?Sized,
+{
+  type Output = usize;
+
+  fn index(&self, key: &Q) -> &Self::Output {
+    self.counts.get(key).unwrap_or(&0)
+  }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,43 +137,31 @@
 //! }
 //! ```
 
-#![cfg_attr(test, feature(test))]
-#![feature(proc_macro_hygiene)]
-#![warn(missing_docs)]
-
-extern crate freqdist;
-extern crate num;
-extern crate phf;
-extern crate rustc_serialize;
-#[cfg(test)]
-extern crate test;
-#[cfg(test)]
-extern crate walkdir;
-
-mod trainer;
-mod util;
+mod freq_dist;
+mod prelude;
 mod token;
 mod tokenizer;
-mod prelude;
+mod trainer;
+mod util;
 
-pub use trainer::{Trainer, TrainingData};
+pub use tokenizer::WordTokenizer;
 pub use tokenizer::{SentenceByteOffsetTokenizer, SentenceTokenizer};
+pub use trainer::{Trainer, TrainingData};
 
 /// Contains traits for configuring all tokenizers, and the trainer. Also
 /// contains default parameters for tokenizers, and the trainer.
 pub mod params {
-  pub use prelude::{DefinesInternalPunctuation, DefinesNonPrefixCharacters,
-                    DefinesNonWordCharacters, DefinesPunctuation, DefinesSentenceEndings, Set,
-                    Standard, TrainerParameters};
+  pub use crate::prelude::{
+    DefinesInternalPunctuation, DefinesNonPrefixCharacters, DefinesNonWordCharacters,
+    DefinesPunctuation, DefinesSentenceEndings, Set, Standard, TrainerParameters,
+  };
 }
 
 #[cfg(test)]
 fn get_test_scenarios(dir_path: &str, raw_path: &str) -> Vec<(Vec<String>, String, String)> {
-  #![allow(unused_must_use)]
-
   use std::fs;
-  use std::path::Path;
   use std::io::Read;
+  use std::path::Path;
 
   use walkdir::WalkDir;
 
@@ -192,9 +180,13 @@ fn get_test_scenarios(dir_path: &str, raw_path: &str) -> Vec<(Vec<String>, Strin
       let rawp = Path::new(raw_path).join(fpath.file_name().unwrap());
 
       fs::File::open(&fpath)
-        .unwrap()
-        .read_to_string(&mut exp_strb);
-      fs::File::open(&rawp).unwrap().read_to_string(&mut raw_strb);
+        .expect("Failed to open a file")
+        .read_to_string(&mut exp_strb)
+        .expect("Failed to read to string");
+      fs::File::open(&rawp)
+        .expect("Failed to open a file")
+        .read_to_string(&mut raw_strb)
+        .expect("Failed to read to string");
 
       // Expected results, split by newlines.
       let exps: Vec<String> = exp_strb.split('\n').map(|s| s.to_string()).collect();

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -18,8 +18,8 @@ pub trait DefinesSentenceEndings {
 
   /// Checks if a character is a sentence ending.
   #[inline]
-  fn is_sentence_ending(c: &char) -> bool {
-    Self::SENTENCE_ENDINGS.contains(c)
+  fn is_sentence_ending(c: char) -> bool {
+    Self::SENTENCE_ENDINGS.contains(&c)
   }
 }
 
@@ -31,22 +31,21 @@ pub trait DefinesInternalPunctuation {
   /// Checks if a character is a legal punctuation character that can occur
   /// within a word.
   #[inline]
-  fn is_internal_punctuation(c: &char) -> bool {
-    Self::INTERNAL_PUNCTUATION.contains(c)
+  fn is_internal_punctuation(c: char) -> bool {
+    Self::INTERNAL_PUNCTUATION.contains(&c)
   }
 }
 
 /// Defines a set of characters that can not occur inside of a word.
 pub trait DefinesNonWordCharacters {
   /// The set of characters that can not occur inside of a word.
-  const NONWORD_CHARS: &'static Set<char> = &phf_set![
-    '?', '!', ')', '"', ';', '}', ']', '*', ':', '@', '\'', '(', '{', '['
-  ];
+  const NONWORD_CHARS: &'static Set<char> =
+    &phf_set!['?', '!', ')', '"', ';', '}', ']', '*', ':', '@', '\'', '(', '{', '['];
 
   /// Checks if a character is one that can not occur inside of a word.
   #[inline]
-  fn is_nonword_char(c: &char) -> bool {
-    Self::NONWORD_CHARS.contains(c)
+  fn is_nonword_char(c: char) -> bool {
+    Self::NONWORD_CHARS.contains(&c)
   }
 }
 
@@ -55,24 +54,23 @@ pub trait DefinesPunctuation {
   /// The set of legal punctuation marks.
   const PUNCTUATION: &'static Set<char> = &phf_set![';', ':', ',', '.', '!', '?'];
 
-  /// Checks if a characters is a legal punctuation mark.
+  /// Checks if a character is a legal punctuation mark.
   #[inline]
-  fn is_punctuation(c: &char) -> bool {
-    Self::PUNCTUATION.contains(c)
+  fn is_punctuation(c: char) -> bool {
+    Self::PUNCTUATION.contains(&c)
   }
 }
 
 /// Defines a set of a characters that can not start a word.
 pub trait DefinesNonPrefixCharacters {
   /// The set of characters that can not start a word.
-  const NONPREFIX_CHARS: &'static Set<char> = &phf_set![
-    '(', '"', '`', '{', '[', ':', ';', '&', '#', '*', '@', ')', '}', ']', '-', ','
-  ];
+  const NONPREFIX_CHARS: &'static Set<char> =
+    &phf_set!['(', '"', '`', '{', '[', ':', ';', '&', '#', '*', '@', ')', '}', ']', '-', ','];
 
   /// Checks if a character can start a word.
   #[inline]
-  fn is_nonprefix_char(c: &char) -> bool {
-    Self::NONPREFIX_CHARS.contains(c)
+  fn is_nonprefix_char(c: char) -> bool {
+    Self::NONPREFIX_CHARS.contains(&c)
   }
 }
 
@@ -84,7 +82,7 @@ pub trait TrainerParameters: DefinesSentenceEndings + DefinesInternalPunctuation
   /// Upper bound score for a token to be considered an abbreviation.
   const ABBREV_UPPER_BOUND: f64 = 5f64;
 
-  /// Disables the abbreviation penalty which exponentially penalizes occurances
+  /// Disables the abbreviation penalty which exponentially penalizes occurrences
   /// of words without a trailing period.
   const IGNORE_ABBREV_PENALTY: bool = false;
 
@@ -107,8 +105,10 @@ pub trait TrainerParameters: DefinesSentenceEndings + DefinesInternalPunctuation
 }
 
 /// Standard settings for all tokenizers, and trainers.
+#[derive(Debug, Clone, Copy)]
 pub struct Standard;
 
+// Use blanket implementations for Standard
 impl DefinesInternalPunctuation for Standard {}
 impl DefinesNonPrefixCharacters for Standard {}
 impl DefinesNonWordCharacters for Standard {}
@@ -116,9 +116,11 @@ impl DefinesPunctuation for Standard {}
 impl DefinesSentenceEndings for Standard {}
 impl TrainerParameters for Standard {}
 
+/// Orthographic context type
 pub type OrthographicContext = u8;
 
-#[derive(PartialEq, Eq)]
+/// Position in orthography
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum OrthographyPosition {
   Initial,
   Internal,
@@ -126,6 +128,8 @@ pub enum OrthographyPosition {
 }
 
 impl OrthographyPosition {
+  /// Convert to byte representation
+  #[inline]
   pub fn as_byte(&self) -> u8 {
     match *self {
       OrthographyPosition::Initial => 0b01000000,
@@ -149,14 +153,16 @@ pub const ORT_LC: OrthographicContext = BEG_LC | MID_LC | UNK_LC;
 /// token. The chars (in ASCII) map to the result of ORing the byte
 /// representation of an OrthographyPosition and LetterCase together.
 pub static ORTHO_MAP: phf::Map<u8, OrthographicContext> = phf_map! {
-  b'B' => BEG_UC, // 66
-  b'"' => MID_UC, // 34
-  b'b' => UNK_UC, // 98
-  b'A' => BEG_LC, // 65
-  b'!' => MID_LC, // 33
-  b'a' => UNK_LC  // 97
+    b'B' => BEG_UC, // 66
+    b'"' => MID_UC, // 34
+    b'b' => UNK_UC, // 98
+    b'A' => BEG_LC, // 65
+    b'!' => MID_LC, // 33
+    b'a' => UNK_LC  // 97
 };
 
+/// Case of a letter
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LetterCase {
   Upper,
   Lower,
@@ -164,7 +170,7 @@ pub enum LetterCase {
 }
 
 impl LetterCase {
-  #[inline(always)]
+  #[inline]
   pub fn as_byte(&self) -> u8 {
     match *self {
       LetterCase::Upper => 0b00000010,


### PR DESCRIPTION
Hey Ferris, I was looking for some punkt-like functionality and came across your crate. It seems it's not been updated in a while and since I need the functionality anyway, decided to update your crate instead.

Test results:
```
rust-punkt % cargo t
   Compiling punkt v1.0.6 ()
    Finished `test` profile [unoptimized + debuginfo] target(s) in 1.13s
     Running unittests src/lib.rs (target/debug/deps/punkt-1af74e20e78321db)

running 8 tests
test token::tests::test_token_flags ... ok
test tokenizer::tests::smoke_test_is_multi_char_pass ... ok
test tokenizer::tests::sentence_tokenizer_issue_8_test ... ok
test trainer::tests::test_data_load_from_json_test ... ok
test tokenizer::tests::sentence_tokenizer_issue_5_test ... ok
test tokenizer::tests::periodctxt_tokenizer_compare_nltk ... ok
test tokenizer::tests::word_tokenizer_compare_nltk ... ok
test tokenizer::tests::sentence_tokenizer_compare_nltk_train_on_document ... ok

test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.10s

   Doc-tests punkt

running 8 tests
test src/lib.rs - (line 103) ... ok
test src/lib.rs - (line 78) ... ok
test src/lib.rs - (line 43) ... ok
test src/tokenizer.rs - tokenizer::SentenceTokenizer (line 448) ... ok
test src/trainer.rs - trainer::TrainingData (line 93) ... ok
test src/tokenizer.rs - tokenizer::SentenceByteOffsetTokenizer (line 343) ... ok
test src/lib.rs - (line 53) ... ok
test src/lib.rs - (line 26) ... ok

test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.20s
```

Bench results:
```
Gnuplot not found, using plotters backend
WordTokenizer/short_doc time:   [61.246 µs 61.474 µs 61.720 µs]
                        change: [-3.5504% -1.4128% -0.0352%] (p = 0.12 > 0.05)
                        No change in performance detected.
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe
WordTokenizer/medium_doc
                        time:   [71.463 µs 71.617 µs 71.792 µs]
                        change: [-1.3709% -0.4776% +0.1211%] (p = 0.26 > 0.05)
                        No change in performance detected.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild
WordTokenizer/long_doc  time:   [3.2085 ms 3.2154 ms 3.2221 ms]
                        change: [-0.4503% -0.0955% +0.2618%] (p = 0.60 > 0.05)
                        No change in performance detected.
WordTokenizer/very_long_doc
                        time:   [11.827 ms 11.925 ms 12.048 ms]
                        change: [-3.6751% -1.1126% +0.8954%] (p = 0.42 > 0.05)
                        No change in performance detected.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high severe

SentenceTokenizer/short_doc
                        time:   [44.690 µs 44.775 µs 44.860 µs]
                        change: [-0.8286% -0.5456% -0.2262%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 7 outliers among 100 measurements (7.00%)
  1 (1.00%) low mild
  5 (5.00%) high mild
  1 (1.00%) high severe
SentenceTokenizer/medium_doc
                        time:   [56.706 µs 56.874 µs 57.086 µs]
                        change: [-0.2393% +1.6224% +4.9058%] (p = 0.26 > 0.05)
                        No change in performance detected.
Found 6 outliers among 100 measurements (6.00%)
  3 (3.00%) high mild
  3 (3.00%) high severe
SentenceTokenizer/long_doc
                        time:   [8.5785 ms 8.5926 ms 8.6067 ms]
                        change: [-1.6259% -0.5729% +0.1424%] (p = 0.25 > 0.05)
                        No change in performance detected.

     Running `rust-punkt/target/release/deps/trainers-190d81f24efadab0 --bench`
Gnuplot not found, using plotters backend
Trainer/short_doc       time:   [120.90 µs 121.10 µs 121.30 µs]
                        change: [-1.0087% -0.7565% -0.4876%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 21 outliers among 100 measurements (21.00%)
  4 (4.00%) low severe
  1 (1.00%) low mild
  12 (12.00%) high mild
  4 (4.00%) high severe
Trainer/medium_doc      time:   [161.96 µs 162.25 µs 162.51 µs]
                        change: [-0.0192% +0.3593% +0.7069%] (p = 0.06 > 0.05)
                        No change in performance detected.
Found 19 outliers among 100 measurements (19.00%)
  2 (2.00%) low severe
  5 (5.00%) low mild
  4 (4.00%) high mild
  8 (8.00%) high severe
Trainer/long_doc        time:   [7.3356 ms 7.3480 ms 7.3614 ms]
                        change: [+0.0040% +0.2177% +0.4423%] (p = 0.05 > 0.05)
                        No change in performance detected.
Found 7 outliers among 100 measurements (7.00%)
  4 (4.00%) high mild
  3 (3.00%) high severe
Trainer/very_long_doc   time:   [25.326 ms 25.433 ms 25.545 ms]
                        change: [-1.2095% +0.4529% +1.5705%] (p = 0.64 > 0.05)
                        No change in performance detected.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild